### PR TITLE
Chapter 7: Advanced routing

### DIFF
--- a/cmd/web/handlers.go
+++ b/cmd/web/handlers.go
@@ -3,17 +3,13 @@ package main
 import (
 	"errors"
 	"fmt"
+	"github.com/go-chi/chi/v5"
 	"net/http"
 	"snippetbox.doanandreas.net/internal/models"
 	"strconv"
 )
 
 func (app *application) home(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path != "/" {
-		app.notFound(w)
-		return
-	}
-
 	snippets, err := app.snippets.Latest()
 	if err != nil {
 		app.serverError(w, err)
@@ -27,7 +23,7 @@ func (app *application) home(w http.ResponseWriter, r *http.Request) {
 }
 
 func (app *application) snippetView(w http.ResponseWriter, r *http.Request) {
-	id, err := strconv.Atoi(r.URL.Query().Get("id"))
+	id, err := strconv.Atoi(chi.URLParam(r, "id"))
 	if err != nil || id < 1 {
 		app.notFound(w)
 		return
@@ -50,12 +46,10 @@ func (app *application) snippetView(w http.ResponseWriter, r *http.Request) {
 }
 
 func (app *application) snippetCreate(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "POST" {
-		w.Header().Set("Allow", http.MethodPost)
-		app.clientError(w, http.StatusMethodNotAllowed)
-		return
-	}
+	w.Write([]byte("Display the form of creating a new snippet..."))
+}
 
+func (app *application) snippetCreatePost(w http.ResponseWriter, r *http.Request) {
 	title := "0 snail"
 	content := "0 snail\nClimb Mount Fuji,\nBut slowly, slowly!\n\n- Kobayashi Issa"
 	expires := 7
@@ -66,5 +60,5 @@ func (app *application) snippetCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	http.Redirect(w, r, fmt.Sprintf("/snippet/view?id=%d", id), http.StatusSeeOther)
+	http.Redirect(w, r, fmt.Sprintf("/snippet/view/%d", id), http.StatusSeeOther)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module snippetbox.doanandreas.net
 go 1.20
 
 require (
+	github.com/go-chi/chi/v5 v5.0.11
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/justinas/alice v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/go-chi/chi/v5 v5.0.11 h1:BnpYbFZ3T3S1WMpD79r7R5ThWX40TaFB7L31Y8xqSwA=
+github.com/go-chi/chi/v5 v5.0.11/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=
 github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/justinas/alice v1.2.0 h1:+MHSA/vccVCF4Uq37S42jwlkvI2Xzl7zTPCN5BnZNVo=

--- a/ui/html/pages/home.tmpl
+++ b/ui/html/pages/home.tmpl
@@ -11,7 +11,7 @@
             </tr>
             {{range .Snippets}}
                 <tr>
-                    <td><a href='/snippet/view?id={{.ID}}'>{{.Title}}</a></td>
+                    <td><a href='/snippet/view/{{.ID}}'>{{.Title}}</a></td>
                     <td>{{humanDate .Created}}</td>
                     <td>#{{.ID}}</td>
                 </tr>


### PR DESCRIPTION
We've used stdlib servemux for our router. However it's a good idea to use 3rd party libraries like `chi` or `gorilla/mux`, because the stdlib one is very minimalistic and lacks features. Chi for lightweight rules, and gorilla mux for something more complicated.

The book uses httprouter, but I will use chi because it's the one most appealing to me.