### PR TITLE
Chapter 12: Using Request Context

### DIFF
--- a/cmd/web/context.go
+++ b/cmd/web/context.go
@@ -1,0 +1,5 @@
+package main
+
+type contextKey string
+
+const isAuthenticatedContextKey = contextKey("isAuthenticated")

--- a/cmd/web/helpers.go
+++ b/cmd/web/helpers.go
@@ -76,5 +76,10 @@ func (app *application) decodePostForm(r *http.Request, dst any) error {
 }
 
 func (app *application) isAuthenticated(r *http.Request) bool {
-	return app.sessionManager.Exists(r.Context(), "authenticatedUserID")
+	isAuthenticated, ok := r.Context().Value(isAuthenticatedContextKey).(bool)
+	if !ok {
+		return false
+	}
+
+	return isAuthenticated
 }

--- a/cmd/web/middleware.go
+++ b/cmd/web/middleware.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"github.com/justinas/nosurf"
 	"net/http"
@@ -64,4 +65,27 @@ func noSurf(next http.Handler) http.Handler {
 	})
 
 	return csrfHandler
+}
+
+func (app *application) authenticate(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := app.sessionManager.GetInt(r.Context(), "authenticatedUserID")
+		if id == 0 {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		exists, err := app.users.Exists(id)
+		if err != nil {
+			app.serverError(w, err)
+			return
+		}
+
+		if exists {
+			ctx := context.WithValue(r.Context(), isAuthenticatedContextKey, true)
+			r = r.WithContext(ctx)
+		}
+
+		next.ServeHTTP(w, r)
+	})
 }

--- a/internal/models/users.go
+++ b/internal/models/users.go
@@ -71,5 +71,10 @@ func (m *UserModel) Authenticate(email, password string) (int, error) {
 }
 
 func (m *UserModel) Exists(id int) (bool, error) {
-	return false, nil
+	var exists bool
+
+	stmt := "SELECT EXISTS(SELECT true FROM users WHERE id = ?)"
+
+	err := m.DB.QueryRow(stmt, id).Scan(&exists)
+	return exists, err
 }


### PR DESCRIPTION
Context can be used to pass information from one middleware to the next. In the book it uses `isAuthenticated` as example, however some golang devs on reddit disagree with this.

Context is mostly used for cancellation and timeouts. And because this is a concurrency pattern that goes way over my head, I'm just gonna be aware of its existence for now. And also understanding the basic intuition of what it's used for.